### PR TITLE
chore: rename proxy execute

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,3 +1,0 @@
-# run testnet
-# dapp testnet
-

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,3 @@
+# run testnet
+# dapp testnet
+

--- a/src/proxy.sol
+++ b/src/proxy.sol
@@ -64,7 +64,7 @@ contract Proxy is TitleOwned {
         }
     }
 
-    function executeWithoutAddress(bytes memory _code, bytes memory _data)
+    function executeByteCode(bytes memory _code, bytes memory _data)
     public
     payable
     owner(accessToken)

--- a/src/proxy.sol
+++ b/src/proxy.sol
@@ -64,7 +64,7 @@ contract Proxy is TitleOwned {
         }
     }
 
-    function execute(bytes memory _code, bytes memory _data)
+    function executeWithoutAddress(bytes memory _code, bytes memory _data)
     public
     payable
     owner(accessToken)

--- a/src/proxy.sol
+++ b/src/proxy.sol
@@ -84,7 +84,7 @@ contract Proxy is TitleOwned {
 // This factory deploys new proxy instances through build()
 // Deployed proxy addresses are logged
 contract ProxyRegistry is Title {
-    event Created(address indexed sender, address indexed owner, address proxy);
+    event Created(address indexed sender, address indexed owner, address proxy, uint tokenId);
     mapping (uint => address) public proxies;
 
     constructor() Title("Tinlake Actions Access Token", "TAAT") public {
@@ -101,7 +101,7 @@ contract ProxyRegistry is Title {
         uint token = _issue(owner);
         proxy = address(new Proxy(token));
         proxies[token] = proxy;
-        emit Created(msg.sender, owner, proxy);
+        emit Created(msg.sender, owner, proxy, token);
     }
 
     // --- Cache ---

--- a/src/test/proxy.t.sol
+++ b/src/test/proxy.t.sol
@@ -111,7 +111,7 @@ contract ProxyTest is DSTest {
         bytes memory data = abi.encodeWithSignature("getBytes32AndUint()");
 
         //deploy and call the contracts code
-        (, bytes memory response) = proxy.executeWithoutAddress(testCode, data);
+        (, bytes memory response) = proxy.executeByteCode(testCode, data);
 
         bytes32 response32;
         uint responseUint;

--- a/src/test/proxy.t.sol
+++ b/src/test/proxy.t.sol
@@ -111,7 +111,7 @@ contract ProxyTest is DSTest {
         bytes memory data = abi.encodeWithSignature("getBytes32AndUint()");
 
         //deploy and call the contracts code
-        (, bytes memory response) = proxy.execute(testCode, data);
+        (, bytes memory response) = proxy.executeWithoutAddress(testCode, data);
 
         bytes32 response32;
         uint responseUint;


### PR DESCRIPTION
to account for the js abi.encoder inability to support overloaded functions